### PR TITLE
Visualize account balances for selected date

### DIFF
--- a/src/apps/obsidian-plugin/views/RightSidebarReactView/AccountingSection/AccountsList.tsx
+++ b/src/apps/obsidian-plugin/views/RightSidebarReactView/AccountingSection/AccountsList.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { RightSidebarReactTab } from "../RightSidebarReactTab";
 import { AccountsContext, ItemsContext } from "../Contexts";
 import { AccountsReport } from "contexts/Reports/domain/accounts-report.entity";
@@ -9,6 +9,8 @@ import {
 	List,
 	ListItem,
 	Typography,
+	Box,
+	Alert,
 } from "@mui/material";
 import { useDateInput } from "apps/obsidian-plugin/components/Input/useDateInput";
 import { DateValueObject } from "@juandardilag/value-objects";
@@ -23,42 +25,66 @@ export const AccountsList = () => {
 	} = useContext(ItemsContext);
 	const [showCreateForm, setShowCreateForm] = useState(false);
 
-	const [project, setProject] = useState(false);
+	const [showProjectedBalances, setShowProjectedBalances] = useState(false);
 	const { date, DateInput } = useDateInput({
 		initialValue: new Date(),
-		label: "Date",
-		lock: !project,
+		label: "Balance Date",
+		lock: false, // Always allow date selection
 	});
 
 	const [itemsWithAccountsBalance, setItemsWithAccountsBalance] = useState<
 		ItemWithAccumulatedBalance[]
 	>([]);
+	
+	const [isLoadingProjection, setIsLoadingProjection] = useState(false);
+
+	// Load projected balances when date or projection toggle changes
 	useEffect(() => {
-		itemsWithAccumulatedBalanceUseCase
-			.execute(new DateValueObject(date))
-			.then(setItemsWithAccountsBalance);
-	}, [date]);
+		if (showProjectedBalances) {
+			setIsLoadingProjection(true);
+			itemsWithAccumulatedBalanceUseCase
+				.execute(new DateValueObject(date))
+				.then((result: ItemWithAccumulatedBalance[]) => {
+					setItemsWithAccountsBalance(result);
+					setIsLoadingProjection(false);
+				})
+				.catch(() => {
+					setIsLoadingProjection(false);
+				});
+		} else {
+			setItemsWithAccountsBalance([]);
+		}
+	}, [date, showProjectedBalances, itemsWithAccumulatedBalanceUseCase]);
 
 	const accountsWithBalance = useMemo(
 		() =>
 			accounts.map((account) => {
-				const newBalance = project
-					? itemsWithAccountsBalance.findLast(
-							({ recurrence: item }) =>
-								item.account?.equalTo(account.id)
-					  )?.accountBalance ?? account.balance
-					: account.balance;
-				account.updateBalance(newBalance);
-				console.log({
-					project,
-					account: account.toPrimitives(),
-					itemsWithAccountsBalance,
-					newBalance: newBalance.value.value,
-				});
-				return account;
+				if (!showProjectedBalances) {
+					return account; // Use current balance
+				}
+
+				// Find the latest balance for this account from projected items
+				const latestProjectedBalance = itemsWithAccountsBalance.findLast(
+					({ recurrence }: ItemWithAccumulatedBalance) =>
+						recurrence.account?.equalTo(account.id)
+				)?.accountBalance;
+
+				if (latestProjectedBalance) {
+					// Create a copy of the account with the projected balance
+					const accountCopy = account.clone();
+					accountCopy.updateBalance(latestProjectedBalance);
+					return accountCopy;
+				}
+
+				return account; // Fallback to current balance
 			}),
-		[accounts, itemsWithAccountsBalance, project]
+		[accounts, itemsWithAccountsBalance, showProjectedBalances]
 	);
+
+	const projectedReport = useMemo(() => new AccountsReport(accountsWithBalance), [accountsWithBalance]);
+
+	const isProjectingToFuture = date > new Date();
+	const isShowingCurrentBalances = !showProjectedBalances;
 
 	return (
 		<RightSidebarReactTab
@@ -76,19 +102,41 @@ export const AccountsList = () => {
 				/>
 			)}
 
-			<FormControlLabel
-				control={
-					<Checkbox
-						checked={project}
-						onChange={(e) => {
-							const checked = e.target.checked;
-							setProject(checked);
-						}}
-					/>
-				}
-				label="Project"
-			/>
-			{DateInput}
+			<Box sx={{ mb: 2 }}>
+				{DateInput}
+				
+				<FormControlLabel
+					control={
+						<Checkbox
+							checked={showProjectedBalances}
+							onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+								setShowProjectedBalances(e.target.checked);
+							}}
+							disabled={isLoadingProjection}
+						/>
+					}
+					label={`Show balances as of ${date.toLocaleDateString()}`}
+				/>
+
+				{showProjectedBalances && isProjectingToFuture && (
+					<Alert severity="info" sx={{ mt: 1, mb: 1 }}>
+						Showing projected balances including scheduled items through {date.toLocaleDateString()}
+					</Alert>
+				)}
+
+				{showProjectedBalances && !isProjectingToFuture && (
+					<Alert severity="warning" sx={{ mt: 1, mb: 1 }}>
+						Showing historical balances as of {date.toLocaleDateString()}
+					</Alert>
+				)}
+
+				{isLoadingProjection && (
+					<Alert severity="info" sx={{ mt: 1, mb: 1 }}>
+						Calculating projected balances...
+					</Alert>
+				)}
+			</Box>
+
 			<Typography variant="h4">
 				Assets{" "}
 				<span
@@ -98,7 +146,12 @@ export const AccountsList = () => {
 						paddingLeft: "5px",
 					}}
 				>
-					Total: {report.getTotalForAssets().toString()}
+					Total: {projectedReport.getTotalForAssets().toString()}
+					{showProjectedBalances && (
+						<span style={{ fontStyle: "italic", marginLeft: "5px" }}>
+							(as of {date.toLocaleDateString()})
+						</span>
+					)}
 				</span>
 			</Typography>
 			<List>
@@ -115,6 +168,7 @@ export const AccountsList = () => {
 						</ListItem>
 					))}
 			</List>
+
 			<Typography variant="h4">
 				Liabilities{" "}
 				<span
@@ -124,7 +178,12 @@ export const AccountsList = () => {
 						paddingLeft: "5px",
 					}}
 				>
-					Total: {report.getTotalForLiabilites().toString()}
+					Total: {projectedReport.getTotalForLiabilites().toString()}
+					{showProjectedBalances && (
+						<span style={{ fontStyle: "italic", marginLeft: "5px" }}>
+							(as of {date.toLocaleDateString()})
+						</span>
+					)}
 				</span>
 			</Typography>
 			<List>
@@ -141,8 +200,16 @@ export const AccountsList = () => {
 						</ListItem>
 					))}
 			</List>
+			
 			<br />
-			<div>Total: {report.getTotal().toString()}</div>
+			<div>
+				Total: {projectedReport.getTotal().toString()}
+				{showProjectedBalances && (
+					<span style={{ fontStyle: "italic", marginLeft: "5px" }}>
+						(as of {date.toLocaleDateString()})
+					</span>
+				)}
+			</div>
 		</RightSidebarReactTab>
 	);
 };


### PR DESCRIPTION
The `AccountsList.tsx` component was updated to enhance date-based balance visualization and state management.

Key changes include:

*   The `DateInput` is now always unlocked, allowing date selection regardless of projection status, with its label updated to "Balance Date".
*   The `project` state was renamed to `showProjectedBalances` for clarity, and a new `isLoadingProjection` state was introduced to manage loading feedback.
*   The `useEffect` hook now conditionally triggers the balance projection calculation only when `showProjectedBalances` is enabled, managing the `isLoadingProjection` state during the process.
*   The account balance calculation in `useMemo` was refined to return a *cloned* account with the projected balance, ensuring immutability of the original account object.
*   UI improvements were made:
    *   The date input and checkbox are wrapped in a `Box` for better layout.
    *   The checkbox label dynamically displays "Show balances as of [selected date]".
    *   `Alert` components provide clear user feedback for future projections, historical views, and loading states.
*   Report totals now use a `projectedReport` derived from the `accountsWithBalance` state, and include an "(as of [date])" indicator when projected balances are displayed.

These changes provide a more intuitive and informative experience for viewing account balances at any specified date, considering scheduled items.